### PR TITLE
Minimal changes required for typechecking to pass

### DIFF
--- a/ts/src/anki.d.ts
+++ b/ts/src/anki.d.ts
@@ -1,0 +1,12 @@
+// Anki doesn't currently provide typings for this module, so we need to declare it ourselves.
+declare module "anki/NoteEditor" {
+    type ContextProperty<T> =
+        import("@anki/sveltelib/context-property").ContextProperty<T>;
+    type LifecycleHooks<T> =
+        import("@anki/sveltelib/lifecycle-hooks").LifecycleHooks<T>;
+    type NoteEditorAPI = import("@anki/editor/NoteEditor.svelte").NoteEditorAPI;
+
+    export const context: ContextProperty<NoteEditorAPI>;
+    export const lifecycle: LifecycleHooks<NoteEditorAPI>;
+    export const instances: NoteEditorAPI[];
+}

--- a/ts/src/editor.ts
+++ b/ts/src/editor.ts
@@ -1,3 +1,6 @@
+// https://github.com/ankitects/anki/issues/1386
+/// <reference path="../../anki/ts/lib/shadow-dom.d.ts" />
+
 import "./styles/fields-grid.scss";
 
 import StrikeThrough from "./StrikeThrough.svelte";

--- a/ts/src/image-import.d.ts
+++ b/ts/src/image-import.d.ts
@@ -1,4 +1,0 @@
-declare module "*.svg" {
-    const icon: string;
-    export default icon;
-}

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -8,11 +8,11 @@
         "noImplicitAny": false,
         "isolatedModules": true,
         "esModuleInterop": true,
-        "skipLibCheck": true,
-        "typeRoots": ["node_modules/@types", "../anki/ts/typings"],
+        "skipLibCheck": false,
+        "typeRoots": ["node_modules/@types"],
         "paths": {
             /* This alias should only be used for typing needs */
-            "@anki/*": ["../anki/ts/*"]
+            "@anki/*": ["../anki/.bazel/bin/ts/*", "../anki/ts/*"]
         }
     }
 }


### PR DESCRIPTION
From ts dir:

- yarn run svelte-check
- ./node_modules/typescript/bin/tsc --noEmit
- no squiggly lines in VS Code

We'll presumably still want to figure out a better way of declaring these dynamic modules/storing the d.ts in the upstream repo so add-on authors don't need to write them themselves, but I figured it was worth posting the current state of affairs. 