### PR TITLE
Fix run.sh

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -10,9 +10,9 @@ git submodule init
 cd "$DIR/anki"
 (
   # Start Anki
-  ANKI_BASE="$DIR/ankidata" "$DIR/anki/scripts/ts-run" &
+  ANKI_BASE="$DIR/ankidata" "$DIR/anki/tools/ts-run" &
   # Watch for changes in Anki TypeScript code
-  "$DIR/anki/scripts/ts-watch" &
+  "$DIR/anki/tools/ts-watch" &
   # Watch for changes in Add-on TypeScript code
   yarn --cwd "$DIR/ts" dev
 )

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -8,4 +8,4 @@ cd "$DIR";
 git submodule init
 
 cd "$DIR/anki";
-ANKI_BASE="$DIR/ankidata" "$DIR/anki/scripts/ts-run"
+ANKI_BASE="$DIR/ankidata" "$DIR/anki/tools/ts-run"


### PR DESCRIPTION
~There is no directory named "scripts" in `anki`.~

I just noticed that there is a `tools` and `scripts` folder which has nearly identical scripts, with the exception that `scripts` references `anki/scripts` and `tools` references `anki/tools`. From my understanding `scripts` was renamed to `tools` in `anki`, so is the duplication just to be backwards compatible with older versions of Anki?